### PR TITLE
Fix errors with shut_down sequence

### DIFF
--- a/lib/lita/adapters/flowdock.rb
+++ b/lib/lita/adapters/flowdock.rb
@@ -25,16 +25,11 @@ module Lita
         )
 
         connector.run
-      rescue Interrupt
-        shut_down
       end
 
       def shut_down
         return unless connector
         connector.shut_down
-      rescue RuntimeError
-        robot.trigger(:disconnected)
-        log.info('Disconnected')
       end
 
       def send_messages(target, messages)

--- a/lib/lita/adapters/flowdock/connector.rb
+++ b/lib/lita/adapters/flowdock/connector.rb
@@ -39,8 +39,9 @@ module Lita
             end
 
             source.error do |error|
-              log.error(error.inspect)
-              EM.stop
+              log.error(error)
+              robot.trigger(:disconnected)
+              log.info('Disconnected')
             end
 
             source.start
@@ -55,6 +56,7 @@ module Lita
 
         def shut_down
           source.close
+          EM.stop if EM.reactor_running?
         end
 
         private


### PR DESCRIPTION
execute `trigger(:disconnected)` from the error event handler

Fixes #3
