### PR TITLE
Respond to messages in a flowdock thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ For quick setup, see the [Getting Started](https://github.com/bhouse/lita-flowdo
 * `organization` (String) - The organization for the flowdock account
 * `flows` (Array) - Array of flows the bot should connect to, i.e. `main`
 
+### Optional Attributes
+* `thread_responses` (Symbol) - Respond to the original message in a Flowdock
+  thread
+ * default: `:enabled`
+ * other values: `:disabled`
+
 ### Example
 
 #### lita_config.rb

--- a/lib/lita/adapters/flowdock.rb
+++ b/lib/lita/adapters/flowdock.rb
@@ -9,6 +9,7 @@ module Lita
       config :api_token, type: String, required: true
       config :organization, type: String, required: true
       config :flows, type: Array, required: true
+      config :thread_responses, type: Symbol, required: false, default: :enabled
 
 
       def mention_format(name)
@@ -33,7 +34,11 @@ module Lita
       end
 
       def send_messages(target, messages)
-        connector.send_messages(target.room, messages)
+        if config.thread_responses.eql?(:enabled)
+          connector.send_messages(target.room, messages, target.message_id)
+        else
+          connector.send_messages(target.room, messages)
+        end
       end
 
       private

--- a/lib/lita/adapters/flowdock/connector.rb
+++ b/lib/lita/adapters/flowdock/connector.rb
@@ -51,9 +51,13 @@ module Lita
           end
         end
 
-        def send_messages(target, messages)
+        def send_messages(target, messages, message_id = nil)
           messages.each do |message|
-            client.chat_message(flow: target, content: message)
+            client.chat_message(
+              flow: target,
+              content: message,
+              message: message_id
+            )
           end
         end
 

--- a/lib/lita/adapters/flowdock/message_handler.rb
+++ b/lib/lita/adapters/flowdock/message_handler.rb
@@ -1,4 +1,5 @@
 require 'lita/adapters/flowdock/users_creator'
+require 'lita/source/flowdock_source'
 
 module Lita
   module Adapters
@@ -33,13 +34,17 @@ module Lita
           end
 
           def dispatch_message(user)
-            source = Source.new(user: user, room: flow)
+            source = FlowdockSource.new(user: user, room: flow, message_id: id)
             message = Message.new(robot, body, source)
             robot.receive(message)
           end
 
           def flow
             data['flow']
+          end
+
+          def id
+            data['id']
           end
 
           def from_self?(user)

--- a/lib/lita/source/flowdock_source.rb
+++ b/lib/lita/source/flowdock_source.rb
@@ -1,0 +1,10 @@
+module Lita
+  class FlowdockSource < Source
+    attr_reader :message_id
+
+    def initialize(user: nil, room: nil, private_message: false, message_id: nil)
+      super(user: user, room: room, private_message: private_message)
+      @message_id = message_id
+    end
+  end
+end

--- a/spec/lita/adapters/flowdock/connector_spec.rb
+++ b/spec/lita/adapters/flowdock/connector_spec.rb
@@ -56,14 +56,15 @@ describe Lita::Adapters::Flowdock::Connector, lita: true do
   describe "#send_messages" do
     let(:target) { 'testing:lita-test' }
     let(:message) { 'foo' }
+    let(:message_id) { 1234 }
 
     before do
       allow(fd_client).to receive(:get).with('/users').and_return(users)
     end
 
     it "sends messages" do
-      expect(fd_client).to receive(:chat_message).with(flow: target, content: message)
-      subject.send_messages(target, [message])
+      expect(fd_client).to receive(:chat_message).with(flow: target, content: message, message: message_id)
+      subject.send_messages(target, [message], message_id)
     end
   end
 end

--- a/spec/lita/adapters/flowdock/message_handler_spec.rb
+++ b/spec/lita/adapters/flowdock/message_handler_spec.rb
@@ -25,23 +25,26 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
 
   describe "#handle" do
     context "a normal message" do
+      let(:id) { 2345 }
       let(:data) do
         {
           'content' => 'Hello World!',
           'event'   => 'message',
           'flow'    => test_flow,
+          'id'      => id,
           'user'    => test_user_id
         }
       end
       let(:message) { instance_double('Lita::Message', command!: false) }
-      let(:source) { instance_double('Lita::Source', private_message?: false) }
+      let(:source) { instance_double('Lita::FlowdockSource', private_message?: false, message_id: id) }
       let(:user) { user_double(test_user_id) }
 
       before do
         allow(Lita::User).to receive(:find_by_id).and_return(user)
-        allow(Lita::Source).to receive(:new).with(
+        allow(Lita::FlowdockSource).to receive(:new).with(
           user: user,
-          room: test_flow
+          room: test_flow,
+          message_id: id
         ).and_return(source)
         allow(Lita::Message).to receive(:new).with(
           robot, 'Hello World!', source).and_return(message)
@@ -60,6 +63,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
             'event'   => 'message',
             'flow'    => test_flow,
             'user'    => test_user_id,
+            'id'      => id
           }
         end
 

--- a/spec/lita/adapters/flowdock_spec.rb
+++ b/spec/lita/adapters/flowdock_spec.rb
@@ -45,16 +45,29 @@ describe Lita::Adapters::Flowdock, lita: true do
   end
 
   describe "#send_messages" do
-    let(:room_source) { Lita::Source.new(room: '1234abcd') }
+    let(:id) { 8888 }
+    let(:room_source) { Lita::FlowdockSource.new(room: '1234abcd', message_id: id) }
     let(:user) { Lita::User.new('987654') }
     let(:user_source) { Lita::Source.new(user: user) }
 
     it "sends messages to flows" do
-      expect(connector).to receive(:send_messages).with(room_source.room, ['foo'])
+      expect(connector).to receive(:send_messages).with(room_source.room, ['foo'], room_source.message_id)
 
       subject.run
 
       subject.send_messages(room_source, ['foo'])
+    end
+
+    context "with thread_responses disabled" do
+      before do
+        registry.config.adapters.flowdock.thread_responses = :disabled
+      end
+
+      it "sends messages to flow without the original message id" do
+        expect(connector).to receive(:send_messages).with(room_source.room, ['foo'])
+        subject.run
+        subject.send_messages(room_source, ['foo'])
+      end
     end
   end
 


### PR DESCRIPTION
Create a new `FlowdockSource` class that inherits from `Lita::Source`, but
includes the original message id as an attribute.

If the adapter is configured to thread responses (default is enabled), then
send any response messages with the original message id, flowdock will handle
the threading.

Fixes https://github.com/bhouse/lita-flowdock/issues/2
