### PR TITLE
relax lita dependency

### DIFF
--- a/lita-flowdock.gemspec
+++ b/lita-flowdock.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", "~> 4.2.0"
+  spec.add_runtime_dependency "lita", "~> 4.2"
   spec.add_runtime_dependency "em-eventsource"
   spec.add_runtime_dependency "flowdock"
 


### PR DESCRIPTION
require lita ~4.2 instead of ~4.2.0, allows upgrading lita bot to v4.3
