### PR TITLE
pass message tags along to handlers

### DIFF
--- a/lib/lita/adapters/flowdock/message_handler.rb
+++ b/lib/lita/adapters/flowdock/message_handler.rb
@@ -1,5 +1,6 @@
 require 'lita/adapters/flowdock/users_creator'
 require 'lita/source/flowdock_source'
+require 'lita/message/flowdock_message'
 
 module Lita
   module Adapters
@@ -55,7 +56,7 @@ module Lita
               room: flow,
               message_id: message_id
             )
-            message = Message.new(robot, body, source)
+            message = FlowdockMessage.new(robot, body, source, tags)
             robot.receive(message)
           end
 

--- a/lib/lita/message/flowdock_message.rb
+++ b/lib/lita/message/flowdock_message.rb
@@ -1,0 +1,9 @@
+module Lita
+  class FlowdockMessage < Message
+    attr_reader :tags
+    def initialize(robot, body, source, tags)
+      @tags = tags
+      super(robot, body, source)
+    end
+  end
+end

--- a/spec/lita/adapters/flowdock/message_handler_spec.rb
+++ b/spec/lita/adapters/flowdock/message_handler_spec.rb
@@ -32,10 +32,11 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           'event'   => 'message',
           'flow'    => test_flow,
           'id'      => id,
+          'tags'    => [],
           'user'    => test_user_id
         }
       end
-      let(:message) { instance_double('Lita::Message', command!: false) }
+      let(:message) { instance_double('Lita::FlowdockMessage', command!: false) }
       let(:source) { instance_double('Lita::FlowdockSource', private_message?: false, message_id: id) }
       let(:user) { user_double(test_user_id) }
 
@@ -46,8 +47,8 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           room: test_flow,
           message_id: id
         ).and_return(source)
-        allow(Lita::Message).to receive(:new).with(
-          robot, 'Hello World!', source).and_return(message)
+        allow(Lita::FlowdockMessage).to receive(:new).with(
+          robot, 'Hello World!', source, []).and_return(message)
         allow(robot).to receive(:receive).with(message)
       end
 
@@ -63,15 +64,17 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
             'event'   => 'message',
             'flow'    => test_flow,
             'user'    => test_user_id,
+            'tags'    => [],
             'id'      => id
           }
         end
 
         it "dispatches an empty message to Lita" do
-          expect(Lita::Message).to receive(:new).with(
+          expect(Lita::FlowdockMessage).to receive(:new).with(
             robot,
             "",
-            source
+            source,
+            []
           ).and_return(message)
 
           subject.handle
@@ -85,6 +88,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           'content' => 'this type is not supported',
           'event'   => 'unsupported',
           'flow'    => test_flow,
+          'tags'    => [],
           'user'    => test_user_id
         }
       end
@@ -102,6 +106,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           'content' => 'reply from lita',
           'event'   => 'message',
           'flow'    => test_flow,
+          'tags'    => [],
           'user'    => robot_id
         }
       end
@@ -128,6 +133,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           'content' => "hi i'm new here",
           'event'   => 'message',
           'flow'    => test_flow,
+          'tags'    => [],
           'user'    => new_user_id
         }
       end
@@ -160,6 +166,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           'content' => { 'last_activity' => 1317715364447 },
           'event'   => 'activity.user',
           'flow'    => test_flow,
+          'tags'    => [],
           'user'    => test_user_id
         }
       end
@@ -174,6 +181,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
     context "receives a comment message" do
       let(:id) { 4321 }
       let(:parent_id) { 123456 }
+      let(:tags) { ["influx:#{parent_id}"] }
       let(:data) do
         {
           'content' => {
@@ -183,7 +191,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           'event'   => 'comment',
           'flow'    => test_flow,
           'id'      => id,
-          'tags'    => ["influx:#{parent_id}"],
+          'tags'    => tags,
           'user'    => test_user_id
         }
       end
@@ -198,8 +206,8 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           room: test_flow,
           message_id: parent_id
         ).and_return(source)
-        allow(Lita::Message).to receive(:new).with(
-          robot, 'Lita: help', source).and_return(message)
+        allow(Lita::FlowdockMessage).to receive(:new).with(
+          robot, 'Lita: help', source, tags).and_return(message)
         allow(robot).to receive(:receive).with(message)
       end
 
@@ -216,6 +224,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
             'content' => {'type' => 'add_people', 'description' => 'user5'},
             'event' => 'action',
             'flow'  => test_flow,
+            'tags'  => [],
             'user'  => test_user_id
           }
         end
@@ -246,6 +255,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
             'content' => {'type' => 'join', 'description' => 'tbd'},
             'event'   => 'action',
             'flow'    => test_flow,
+            'tags'    => [],
             'user'    => joining_user_id
           }
         end
@@ -275,6 +285,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
             },
             'event'   => 'action',
             'flow'    => test_flow,
+            'tags'    => [],
             'user'    => test_user_id
           }
         end

--- a/spec/lita/message/flowdock_message_spec.rb
+++ b/spec/lita/message/flowdock_message_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe Lita::FlowdockMessage, lita: true do
+  let(:message_handler) do
+    Lita::Adapters::Flowdock::MessageHandler.new(
+      robot,
+      123456,
+      data,
+      fd_client
+    )
+  end
+
+  let(:source) { instance_double('Lita::FlowdockSource', private_message?: false, message_id: 1234) }
+
+  let(:robot) { Lita::Robot.new(registry) }
+  let(:fd_client) { instance_double('Flowdock::Client') }
+  let(:test_flow) { 'testing:lita-test' }
+  let(:test_user_id) { 3 }
+  let(:test_fd_user) { user_hash(test_user_id) }
+  let(:user) { user_double(test_user_id) }
+
+  before do
+    allow(fd_client).to receive(:get).with("/user/3").and_return(test_fd_user)
+    allow(Lita::FlowdockSource).to receive(:new).with(
+      user: user,
+      room: test_flow,
+      message_id: 1234
+    ).and_return(source)
+    allow(Lita::User).to receive(:find_by_id).and_return(user)
+  end
+
+  context "a message in a thread has a tag" do
+    let(:tags) { ['influx:1234', 'down'] }
+    let(:body) { 'the system is #down' }
+    let(:data) do
+      {
+        'content' => {
+          'title' => 'Thread title',
+          'text'  => body
+        },
+        'event'   => 'comment',
+        'flow'    => test_flow,
+        'id'      => 1234,
+        'tags'    => tags,
+        'user'    => 3
+      }
+    end
+
+    it 'creates a message with tags' do
+      expect(Lita::FlowdockMessage).to receive(:new).with(
+        robot,
+        body,
+        source,
+        tags
+      )
+
+      message_handler.handle
+    end
+  end
+
+  context 'a regular message with a tag' do
+    let(:tags) { ['world'] }
+    let(:body) { 'Hello #world' }
+    let(:data) do
+      {
+        'content' => body,
+        'event'   => 'message',
+        'flow'    => test_flow,
+        'id'      => 1234,
+        'tags'    => tags,
+        'user'    => 3
+      }
+    end
+
+    it 'creates a message with tags' do
+      expect(Lita::FlowdockMessage).to receive(:new).with(
+        robot,
+        body,
+        source,
+        tags
+      )
+
+      message_handler.handle
+    end
+  end
+end


### PR DESCRIPTION
add message.tags method to messages passed to handlers with the array of tags
from flowdock
