### PR TITLE
use initial_message key instead of influx tag

### DIFF
--- a/lib/lita/adapters/flowdock/message_handler.rb
+++ b/lib/lita/adapters/flowdock/message_handler.rb
@@ -41,20 +41,11 @@ module Lita
             data['tags']
           end
 
-          def parent_id
-            influx_tag = tags.select { |t| t =~ /influx:(\d+)/ }.first
-            influx_tag.split(':')[-1].to_i
-          end
-
-          def message_id
-            type == 'comment' ? parent_id : id
-          end
-
           def dispatch_message(user)
             source = FlowdockSource.new(
               user: user,
               room: flow,
-              message_id: message_id
+              message_id: data['initial_message']
             )
             message = FlowdockMessage.new(robot, body, source, tags)
             robot.receive(message)

--- a/lib/lita/adapters/flowdock/message_handler.rb
+++ b/lib/lita/adapters/flowdock/message_handler.rb
@@ -55,10 +55,6 @@ module Lita
             data['flow']
           end
 
-          def id
-            data['id']
-          end
-
           def from_self?(user)
             user.id.to_i == robot_id
           end

--- a/spec/lita/adapters/flowdock/message_handler_spec.rb
+++ b/spec/lita/adapters/flowdock/message_handler_spec.rb
@@ -28,12 +28,13 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
       let(:id) { 2345 }
       let(:data) do
         {
-          'content' => 'Hello World!',
-          'event'   => 'message',
-          'flow'    => test_flow,
-          'id'      => id,
-          'tags'    => [],
-          'user'    => test_user_id
+          'content'         => 'Hello World!',
+          'event'           => 'message',
+          'flow'            => test_flow,
+          'id'              => id,
+          'initial_message' => id,
+          'tags'            => [],
+          'user'            => test_user_id
         }
       end
       let(:message) { instance_double('Lita::FlowdockMessage', command!: false) }
@@ -61,11 +62,12 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
       context "when the message is nil" do
         let(:data) do
           {
-            'event'   => 'message',
-            'flow'    => test_flow,
-            'user'    => test_user_id,
-            'tags'    => [],
-            'id'      => id
+            'event'           => 'message',
+            'flow'            => test_flow,
+            'user'            => test_user_id,
+            'tags'            => [],
+            'id'              => id,
+            'initial_message' => id
           }
         end
 
@@ -181,18 +183,19 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
     context "receives a comment message" do
       let(:id) { 4321 }
       let(:parent_id) { 123456 }
-      let(:tags) { ["influx:#{parent_id}"] }
+      let(:tags) { [] }
       let(:data) do
         {
           'content' => {
-            'title' => 'Thread title',
-            'text' => 'Lita: help'
+            'title'         => 'Thread title',
+            'text'          => 'Lita: help'
           },
-          'event'   => 'comment',
-          'flow'    => test_flow,
-          'id'      => id,
-          'tags'    => tags,
-          'user'    => test_user_id
+          'event'           => 'comment',
+          'flow'            => test_flow,
+          'id'              => id,
+          'initial_message' => parent_id,
+          'tags'            => tags,
+          'user'            => test_user_id
         }
       end
       let(:message) { instance_double('Lita::Message', command!: true) }

--- a/spec/lita/message/flowdock_message_spec.rb
+++ b/spec/lita/message/flowdock_message_spec.rb
@@ -30,19 +30,20 @@ describe Lita::FlowdockMessage, lita: true do
   end
 
   context "a message in a thread has a tag" do
-    let(:tags) { ['influx:1234', 'down'] }
+    let(:tags) { ['down'] }
     let(:body) { 'the system is #down' }
     let(:data) do
       {
-        'content' => {
-          'title' => 'Thread title',
-          'text'  => body
+        'content'         => {
+          'title'         => 'Thread title',
+          'text'          => body
         },
-        'event'   => 'comment',
-        'flow'    => test_flow,
-        'id'      => 1234,
-        'tags'    => tags,
-        'user'    => 3
+        'event'           => 'comment',
+        'flow'            => test_flow,
+        'id'              => 2345,
+        'initial_message' => 1234,
+        'tags'            => tags,
+        'user'            => 3
       }
     end
 
@@ -63,12 +64,13 @@ describe Lita::FlowdockMessage, lita: true do
     let(:body) { 'Hello #world' }
     let(:data) do
       {
-        'content' => body,
-        'event'   => 'message',
-        'flow'    => test_flow,
-        'id'      => 1234,
-        'tags'    => tags,
-        'user'    => 3
+        'content'         => body,
+        'event'           => 'message',
+        'flow'            => test_flow,
+        'id'              => 1234,
+        'initial_message' => 1234,
+        'tags'            => tags,
+        'user'            => 3
       }
     end
 


### PR DESCRIPTION
Flowdock streaming api now provides an `initial_message` key to each message
instead of tagging comments with the parent message id with `influx`
