### PR TITLE
Add the thread_id to the message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
-cache:
-- bundler
 language: ruby
 rvm:
   - 2.2.0
 script: bundle exec rake
-before_install:
-  - gem update --system
 services:
   - redis-server

--- a/lib/lita/adapters/flowdock/message_handler.rb
+++ b/lib/lita/adapters/flowdock/message_handler.rb
@@ -41,6 +41,10 @@ module Lita
             data['tags']
           end
 
+          def thread_id
+            data['thread_id']
+          end
+
           def dispatch_message(user)
             source = FlowdockSource.new(
               user: user,
@@ -48,7 +52,7 @@ module Lita
               private_message: private_message?,
               message_id: private_message? ? data['id'] : data['thread']['initial_message']
             )
-            message = FlowdockMessage.new(robot, body, source, tags)
+            message = FlowdockMessage.new(robot, body, source, tags, thread_id)
             robot.receive(message)
           end
 

--- a/lib/lita/message/flowdock_message.rb
+++ b/lib/lita/message/flowdock_message.rb
@@ -1,8 +1,9 @@
 module Lita
   class FlowdockMessage < Message
-    attr_reader :tags
-    def initialize(robot, body, source, tags)
+    attr_reader :tags, :thread_id
+    def initialize(robot, body, source, tags, thread_id)
       @tags = tags
+      @thread_id = thread_id
       super(robot, body, source)
     end
   end

--- a/lita-flowdock.gemspec
+++ b/lita-flowdock.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "bump"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/spec/lita/adapters/flowdock/message_handler_spec.rb
+++ b/spec/lita/adapters/flowdock/message_handler_spec.rb
@@ -52,7 +52,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           message_id: id
         ).and_return(source)
         allow(Lita::FlowdockMessage).to receive(:new).with(
-          robot, 'Hello World!', source, []).and_return(message)
+          robot, 'Hello World!', source, [], nil).and_return(message)
         allow(robot).to receive(:receive).with(message)
       end
 
@@ -81,7 +81,8 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
             robot,
             "",
             source,
-            []
+            [],
+            nil
           ).and_return(message)
 
           subject.handle
@@ -221,7 +222,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           message_id: parent_id
         ).and_return(source)
         allow(Lita::FlowdockMessage).to receive(:new).with(
-          robot, 'Lita: help', source, tags).and_return(message)
+          robot, 'Lita: help', source, tags, nil).and_return(message)
         allow(robot).to receive(:receive).with(message)
       end
 

--- a/spec/lita/message/flowdock_message_spec.rb
+++ b/spec/lita/message/flowdock_message_spec.rb
@@ -55,7 +55,42 @@ describe Lita::FlowdockMessage, lita: true do
         robot,
         body,
         source,
-        tags
+        tags,
+        nil
+      )
+
+      message_handler.handle
+    end
+  end
+
+  context "a message in a thread" do
+    let(:tags) { ['down'] }
+    let(:body) { 'the system is #down' }
+    let(:data) do
+      {
+        'content'         => {
+          'title'         => 'Thread title',
+          'text'          => body
+        },
+        'event'           => 'comment',
+        'flow'            => test_flow,
+        'id'              => 2345,
+        'thread_id'     => 'deadbeef',
+        'thread'          => {
+          'initial_message' => 1234
+        },
+        'tags'            => tags,
+        'user'            => 3
+      }
+    end
+
+    it 'stores the message_id on the flowdock_message' do
+      expect(Lita::FlowdockMessage).to receive(:new).with(
+        robot,
+        body,
+        source,
+        tags,
+        'deadbeef'
       )
 
       message_handler.handle
@@ -84,7 +119,8 @@ describe Lita::FlowdockMessage, lita: true do
         robot,
         body,
         source,
-        tags
+        tags,
+        nil
       )
 
       message_handler.handle


### PR DESCRIPTION
Threads in flowdock are important. A thread gives a command context and adding the thread_id allows plugins to be context-aware. They can see what was said in the past and respond to it with more information.
