### PR TITLE
handle_tag_change

### DIFF
--- a/lib/lita/adapters/flowdock/message_handler.rb
+++ b/lib/lita/adapters/flowdock/message_handler.rb
@@ -24,6 +24,8 @@ module Lita
             handle_user_activity
           when "action"
             handle_action
+          when "tag-change"
+            handle_tag_change
           else
             handle_unknown
           end
@@ -85,6 +87,10 @@ module Lita
             if %w{add_people join}.include?(data['content']['type'])
               UsersCreator.create_users(flowdock_client.get('/users'))
             end
+          end
+
+          def handle_tag_change
+            robot.trigger(:tag_change, added: data['content']['add'], removed: data['content']['remove'], message: data['content']['message'])
           end
 
           def handle_unknown

--- a/spec/lita/adapters/flowdock/message_handler_spec.rb
+++ b/spec/lita/adapters/flowdock/message_handler_spec.rb
@@ -90,6 +90,28 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
       end
     end
 
+    context "a tag-change event" do
+      let(:data) do
+        {
+          'content' => {
+            'add'   => ['foo'],
+            'remove' => ['bar'],
+            'message' => ['I have #foo']
+          },
+          'event'   => 'tag-change',
+          'flow'    => test_flow,
+          'tags'    => [],
+          'user'    => test_user_id
+        }
+      end
+
+      it 'triggers tag-change trigger' do
+        expect(robot).to receive(:trigger).with(:tag_change, added: ['foo'], removed: ['bar'], message: ['I have #foo'])
+
+        subject.handle
+      end
+    end
+
     context "a message with an unsupported type" do
       let(:data) do
         {


### PR DESCRIPTION
@bhouse this PR should allow any plugin to have a block like this:

``` ruby
on(:tag_change) do |payload|
    do something cool
end
```

That is fired when there is a tag change on a thread/message. This is useful if you use tags as a way to indicate state.

Thoughts?
